### PR TITLE
Update expectation syntax

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,11 +9,11 @@ GEM
   specs:
     diff-lcs (1.2.5)
     mono_logger (1.1.0)
-    multi_json (1.11.0)
-    rack (1.6.1)
+    multi_json (1.11.2)
+    rack (1.6.4)
     rack-protection (1.5.3)
       rack
-    rake (10.3.2)
+    rake (10.4.2)
     redis (3.2.1)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
@@ -23,18 +23,19 @@ GEM
       redis-namespace (~> 1.3)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
-    rspec (3.1.0)
-      rspec-core (~> 3.1.0)
-      rspec-expectations (~> 3.1.0)
-      rspec-mocks (~> 3.1.0)
-    rspec-core (3.1.2)
-      rspec-support (~> 3.1.0)
-    rspec-expectations (3.1.0)
+    rspec (3.3.0)
+      rspec-core (~> 3.3.0)
+      rspec-expectations (~> 3.3.0)
+      rspec-mocks (~> 3.3.0)
+    rspec-core (3.3.2)
+      rspec-support (~> 3.3.0)
+    rspec-expectations (3.3.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.1.0)
-    rspec-mocks (3.1.0)
-      rspec-support (~> 3.1.0)
-    rspec-support (3.1.0)
+      rspec-support (~> 3.3.0)
+    rspec-mocks (3.3.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-support (3.3.0)
     sinatra (1.4.6)
       rack (~> 1.4)
       rack-protection (~> 1.4)
@@ -50,3 +51,6 @@ DEPENDENCIES
   rake
   resqutils!
   rspec
+
+BUNDLED WITH
+   1.10.6

--- a/lib/resqutils/spec/resque_matchers.rb
+++ b/lib/resqutils/spec/resque_matchers.rb
@@ -12,7 +12,7 @@ RSpec::Matchers.define :have_job_queued do |expected_job_hash|
     jobs_matching(queue_name,expected_job_hash).first.size == 1
   end
 
-  failure_message_for_should do |queue_name|
+  failure_message do |queue_name|
     matching_jobs,all_jobs = jobs_matching(queue_name,expected_job_hash)
     if matching_jobs.empty?
       "No jobs in #{queue_name} matched #{expected_job_hash.inspect} (Found these jobs: #{all_jobs.map(&:inspect).join(',')})"
@@ -21,7 +21,7 @@ RSpec::Matchers.define :have_job_queued do |expected_job_hash|
     end
   end
 
-  failure_message_for_should_not do |queue_name|
+  failure_message_when_negated do |queue_name|
     "Found job #{expected_job_hash.inspect} in the queue"
   end
 end


### PR DESCRIPTION
Rspec 3.3 no longer supports the old failure message syntax.

(Also ran bundle update.)