### PR TITLE
Support RSpec 2 and RSpec 3 define matcher messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ rvm:
   - 2.0.0
   - 1.9.3
   - ruby-head
+gemfile:
+  - Gemfile
+  - gemfiles/rspec2.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,3 @@ rvm:
 gemfile:
   - Gemfile
   - gemfiles/rspec2.gemfile
-env:
-  - RESQUTILS_SECONDS_TO_BE_CONSIDERED_STALE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ rvm:
 gemfile:
   - Gemfile
   - gemfiles/rspec2.gemfile
+env:
+  - RESQUTILS_SECONDS_TO_BE_CONSIDERED_STALE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: ruby
 rvm:
   - 2.1.0
   - 2.2.0
+  - 2.0.0
+  - 1.9.3
+  - ruby-head

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,8 @@ GEM
   remote: https://www.rubygems.org/
   specs:
     diff-lcs (1.2.5)
+    fakeredis (0.5.0)
+      redis (~> 3.0)
     mono_logger (1.1.0)
     multi_json (1.11.2)
     rack (1.6.4)
@@ -48,6 +50,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  fakeredis
   rake
   resqutils!
   rspec

--- a/gemfiles/rspec2.gemfile
+++ b/gemfiles/rspec2.gemfile
@@ -1,0 +1,7 @@
+source 'https://www.rubygems.org'
+
+group :test, :development do
+  gem "rspec", "~> 2"
+end
+
+gemspec path: "../"

--- a/gemfiles/rspec2.gemfile.lock
+++ b/gemfiles/rspec2.gemfile.lock
@@ -8,6 +8,8 @@ GEM
   remote: https://www.rubygems.org/
   specs:
     diff-lcs (1.2.5)
+    fakeredis (0.5.0)
+      redis (~> 3.0)
     mono_logger (1.1.0)
     multi_json (1.11.2)
     rack (1.6.4)
@@ -43,6 +45,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  fakeredis
   rake
   resqutils!
   rspec (~> 2)
+
+BUNDLED WITH
+   1.10.6

--- a/gemfiles/rspec2.gemfile.lock
+++ b/gemfiles/rspec2.gemfile.lock
@@ -1,0 +1,48 @@
+PATH
+  remote: ../
+  specs:
+    resqutils (1.1.1)
+      resque
+
+GEM
+  remote: https://www.rubygems.org/
+  specs:
+    diff-lcs (1.2.5)
+    mono_logger (1.1.0)
+    multi_json (1.11.2)
+    rack (1.6.4)
+    rack-protection (1.5.3)
+      rack
+    rake (10.4.2)
+    redis (3.2.1)
+    redis-namespace (1.5.2)
+      redis (~> 3.0, >= 3.0.4)
+    resque (1.25.2)
+      mono_logger (~> 1.0)
+      multi_json (~> 1.0)
+      redis-namespace (~> 1.3)
+      sinatra (>= 0.9.2)
+      vegas (~> 0.1.2)
+    rspec (2.99.0)
+      rspec-core (~> 2.99.0)
+      rspec-expectations (~> 2.99.0)
+      rspec-mocks (~> 2.99.0)
+    rspec-core (2.99.2)
+    rspec-expectations (2.99.2)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.99.4)
+    sinatra (1.4.6)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    tilt (2.0.1)
+    vegas (0.1.11)
+      rack (>= 1.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rake
+  resqutils!
+  rspec (~> 2)

--- a/lib/resqutils/spec/resque_matchers.rb
+++ b/lib/resqutils/spec/resque_matchers.rb
@@ -12,7 +12,13 @@ RSpec::Matchers.define :have_job_queued do |expected_job_hash|
     jobs_matching(queue_name,expected_job_hash).first.size == 1
   end
 
-  failure_message do |queue_name|
+  failure_message_method = if defined?(failure_message)
+                             :failure_message
+                           else
+                             :failure_message_for_should
+                           end
+
+  send(failure_message_method) do |queue_name|
     matching_jobs,all_jobs = jobs_matching(queue_name,expected_job_hash)
     if matching_jobs.empty?
       "No jobs in #{queue_name} matched #{expected_job_hash.inspect} (Found these jobs: #{all_jobs.map(&:inspect).join(',')})"
@@ -21,7 +27,13 @@ RSpec::Matchers.define :have_job_queued do |expected_job_hash|
     end
   end
 
-  failure_message_when_negated do |queue_name|
+  failure_message_when_negated_method = if defined?(failure_message_when_negated)
+                                          :failure_message_when_negated
+                                        else
+                                          :failure_message_for_should_not
+                                        end
+
+  send(failure_message_when_negated_method) do |queue_name|
     "Found job #{expected_job_hash.inspect} in the queue"
   end
 end

--- a/lib/resqutils/stale_workers_killer.rb
+++ b/lib/resqutils/stale_workers_killer.rb
@@ -6,8 +6,8 @@ module Resqutils
       self.new.kill_stale_workers
     end
 
-    def initialize(stale_workers: nil)
-      @stale_workers = stale_workers || Resqutils::StaleWorkers.new
+    def initialize(options={})
+      @stale_workers = options.fetch(:stale_workers, Resqutils::StaleWorkers.new)
     end
     def kill_stale_workers
       @stale_workers.each do |worker|

--- a/resqutils.gemspec
+++ b/resqutils.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("resque")
   s.add_development_dependency("rake")
   s.add_development_dependency("rspec")
+  s.add_development_dependency("fakeredis")
 end

--- a/spec/resque_matchers_spec.rb
+++ b/spec/resque_matchers_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+require 'rspec/version'
+
+describe "Resque RSpec custom matchers" do
+  include Resqutils::Spec::ResqueHelpers
+
+  context "have_job_queued" do
+    class BackgroundJob
+      @queue = :low
+
+      def self.perform
+      end
+    end
+
+    class Service
+      def expensive
+        Resque.enqueue(BackgroundJob)
+      end
+    end
+
+    before do
+      clear_queue(BackgroundJob)
+    end
+
+    it "asserts Resque job has been queued" do
+      Service.new.expensive
+
+      if RSpec::Version::STRING.start_with?("2")
+        "low".should have_job_queued(class: BackgroundJob, args: [])
+      else
+        expect("low").to have_job_queued(class: BackgroundJob, args: [])
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'fakeredis'
 require 'resque'
 require 'resqutils'
 require 'resqutils/spec'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'resque'
 require 'resqutils'
+require 'resqutils/spec'
 
 GEM_ROOT = File.expand_path(File.join(File.dirname(__FILE__),'..'))
 Dir["#{GEM_ROOT}/spec/support/**/*.rb"].sort.each {|f| require f}

--- a/spec/stale_workers_spec.rb
+++ b/spec/stale_workers_spec.rb
@@ -14,8 +14,11 @@ describe Resqutils::StaleWorkers do
       ]
     }
 
-    before do
+    after do
       ENV.delete("RESQUTILS_SECONDS_TO_BE_CONSIDERED_STALE")
+    end
+
+    before do
       allow(Resque).to receive(:workers).and_return(workers)
     end
 


### PR DESCRIPTION
### Problem
#5 was merged to master and dropped RSpec 2 support.  To release and follow [Semantic Versioning](http://semver.org/), `resqutils` would require a major bump.  :cry: 

> MAJOR version when you make incompatible API changes,

### Solution
Use Ruby's [defined? keyword](https://github.com/ruby/ruby/blob/v2_2_3/doc/keywords.rdoc) to figure out which [RSpec define matcher](https://www.relishapp.com/rspec/rspec-expectations/v/3-3/docs/custom-matchers/define-matcher) failure message methods are in scope.

- RSpec 2
  - `failure_message_for_should` 
  - `failure_message_for_should_not`
- RSpec 3 
  - `failure_message`
  - `failure_message_when_negated`

### Testing

https://github.com/simeonwillbanks/rspec-matchers_test was created to test the `defined?` conditional.  It [has a simple module](https://github.com/simeonwillbanks/rspec-matchers_test/blob/master/lib/rspec/matchers_test.rb#L4-L14) where we can [test colors](https://github.com/simeonwillbanks/rspec-matchers_test/blob/master/spec/rspec-matchers_test_spec.rb#L34-L35). 

It defines the [`be_blue` matcher](https://github.com/simeonwillbanks/rspec-matchers_test/blob/master/spec/rspec-matchers_test_spec.rb#L3), and it uses the [same conditionals](https://github.com/simeonwillbanks/rspec-matchers_test/blob/master/spec/rspec-matchers_test_spec.rb#L8-L30) as this Pull Request.

The specs will **always fail**, so we can see the `be_blue` matcher use the `defined?` conditionals.  There are two `puts` statements, so we can see the methods used.

 - [`failure_message_method`](https://github.com/simeonwillbanks/rspec-matchers_test/blob/master/spec/rspec-matchers_test_spec.rb#L14)
 - [`failure_message_when_negated_method`](https://github.com/simeonwillbanks/rspec-matchers_test/blob/master/spec/rspec-matchers_test_spec.rb#L26)

Here's an [RSpec 2 build](https://travis-ci.org/simeonwillbanks/rspec-matchers_test/builds/83396296), and we see it [using the RSpec 2 methods `failure_message_for_should` and `failure_message_for_should_not`](https://travis-ci.org/simeonwillbanks/rspec-matchers_test/builds/83396296#L129-L130).

Here's an [RSpec 3 build](https://travis-ci.org/simeonwillbanks/rspec-matchers_test/builds/83395368), and we it [using the RSpec 3 methods `failure_message` and `failure_message_when_negated`](https://travis-ci.org/simeonwillbanks/rspec-matchers_test/builds/83395368#L130-L131). 

I didn't see how to add tests in `resqutils` without multiple `Gemfile`s.  If there is another way, please let me know.  Thanks!
