### PR TITLE
Replace should matcher with expect if rspec > 3.0

### DIFF
--- a/lib/resqutils/spec/resque_helpers.rb
+++ b/lib/resqutils/spec/resque_helpers.rb
@@ -26,7 +26,11 @@ module Resqutils::Spec::ResqueHelpers
           end
     raise "No jobs on #{queue}" if job.nil?
     klass = job["class"].constantize
-    klass.should == expected_class
+    if Gem.loaded_specs['rspec'].version >= Gem::Version.new('3')
+      expect(klass).to eq(expected_class)
+    else
+      klass.should == expected_class
+    end
     block.call(job)
     klass.perform(*job["args"])
   end


### PR DESCRIPTION
# Problem
The spec helper `process_resque_job` uses an rspec 2 style `should` test which generates deprecation warnings unless you explicitly enable using the old syntax in your rspec configuration.

#Solution
Determine if the rspec gem is 3.0 or later and if so, use `expect` syntax instead of `should`