### PR TITLE
Make App Platform CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,4 +8,4 @@
 # This file uses the GitHub CODEOWNERS convention to assign PR reviewers:
 # https://help.github.com/articles/about-codeowners/
 
-* @stitchfix/dev-platform
+* @stitchfix/app-platform


### PR DESCRIPTION
## Problem

While this repo is identified as owned by [App Platform](https://unwritten.stitchfix.com/teams/App%20Platform) in Unwritten, it is not specified as "[CODEOWNER](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)" and so the team won't get updates about PRs and other changes.

## Solution

Add `@stitchfix/app-platform` to CODEOWNERS file 😀